### PR TITLE
#3 add mock data

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,0 +1,110 @@
+/**
+ * demo.js
+ * 
+ * Basic proof of concept for mapping relational data to a document database.
+ */
+
+const http = require('http');
+const fs = require('fs');
+
+const HOST = 'localhost';
+const PORT = 5984;
+const AUTH = 'admin:pass';
+
+const get = path => new Promise((resolve, reject) => {
+    const options = {
+        hostname: HOST,
+        port: PORT,
+        path,
+        method: 'GET',
+        auth: AUTH,
+    }
+
+    const buffer = [];
+    const request = http.request(options, response => {
+        response.on('data', data => buffer.push(data));
+        response.on('end', () => {
+            try {
+                const body = Buffer.concat(buffer).toString();
+                resolve(JSON.parse(body));
+            } catch (e) {
+              console.error(e.message);
+            }
+          });
+    })
+    
+    request.on('error', error => reject(error));
+    request.end();
+});
+
+const put = (path, data = {}) => new Promise((resolve, reject) => {
+    const body = JSON.stringify(data);
+
+    const options = {
+        hostname: HOST,
+        port: PORT,
+        path,
+        method: 'PUT',
+        auth: AUTH,
+        headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': body.length
+        }
+    }
+
+
+    const buffer = [];
+    const req = http.request(options, response => {
+        response.on('data', data => buffer.push(data));
+        response.on('end', () => {
+            try {
+                const body = Buffer.concat(buffer).toString();
+                resolve(JSON.parse(body));
+            } catch (e) {
+              console.error(e.message);
+            }
+          });
+    })
+    
+    req.on('error', error => reject(error));
+    req.write(body);
+    req.end();
+});
+
+const main = async () => {
+    const stores = JSON.parse(fs.readFileSync('stores.json', 'utf8'));
+    const items = JSON.parse(fs.readFileSync('items.json', 'utf8'));
+    const storeItems = JSON.parse(fs.readFileSync('store_item.json', 'utf8'));
+
+    // Create ocsupply database.
+    await put('/ocsupply');
+
+    // Setup store keys.
+    await stores.reduce(async (promise, store, index) => {
+        await promise;
+        const { uuids } = await get('/_uuids');
+        const [id] = uuids;
+        stores[index] = { ...store, id };
+    }, Promise.resolve());
+
+    // Add store documents.
+    await stores.reduce(async (promise, store) => {
+        await promise;
+        const { id } = store;
+        await put(`/ocsupply/${id}`, store);
+    }, Promise.resolve());
+
+    // Add store items.
+    await storeItems.reduce(async (promise, storeItem) => {
+        await promise;
+        const { store: storeCode, items: itemCodes  } = storeItem;
+        const { id: storeId } = stores.find(store => store.code === storeCode)
+        // Update store document.
+        const oldStore = await get(`/ocsupply/${storeId}`)
+        const newItems = itemCodes.map(code => items.find(item => item.code === code));
+        const newStore = { ...oldStore, items: newItems };
+        await put(`/ocsupply/${storeId}`, newStore);
+    }, Promise.resolve());
+}
+
+main();

--- a/scripts/items.json
+++ b/scripts/items.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Aspirin",
+        "code": "ASPI"
+    },
+    {
+        "name": "Paracetamol",
+        "code": "PARA"
+    },
+    {
+        "name": "Ibuprofen",
+        "code": "IBUP"
+    }
+]

--- a/scripts/store_item.json
+++ b/scripts/store_item.json
@@ -1,0 +1,14 @@
+[
+    {
+        "store": "A",
+        "items": ["ASPI", "PARA", "IBUP"]
+    },
+    {
+        "store": "B",
+        "items": ["ASPI", "PARA"]
+    },
+    {
+        "store": "C",
+        "items": ["IBUP"]
+    }
+]

--- a/scripts/stores.json
+++ b/scripts/stores.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "Facility A",
+        "code": "A"
+    },
+    {
+        "name": "Facility B",
+        "code": "B"
+    },
+    {
+        "name": "Facility C",
+        "code": "C"
+    }
+]


### PR DESCRIPTION
Fixes #3.

So far just items and stores, but a nice little demo of how relational data can be "map-reduced" into key-value documents.

Will do a bit more tomorrow, but thinking of leaving this as is and moving onto replication. My thinking is to do something similar, but add some mock data which associates stores with sites. Spin up a couple of "satellite" CouchDB docker instances, specify a local address for each one and have a one-to-one mapping between these hostnames and sites. Can then demo "master-to-slave" replication across different sites and show how each database is receiving only the slice of data from the master which is associated with its hostname/site. Nothing fancy, but after spending a few hours on this, don't want to be too ambitious... realised it's a bit more time consuming that I thought! 

After that, next steps in my head would be demoing "slave-to-slave" replication, e.g. a satellite instance replicates up some data to the master, which replicates it down to another store.

After doing that, I think we have a complete proof-of-concept of how the existing system can be implemented using CouchDB!

Thoughts?