### PR TITLE
#8 graphql resolvers

### DIFF
--- a/src/schema/Query.ts
+++ b/src/schema/Query.ts
@@ -1,30 +1,46 @@
 import { gql } from "apollo-server";
 
+import { items, stores, requisitions, requisitionLines } from "./mockData";
+
 export const QuerySchema = gql`
   """
   Types which can be queried indepdently should live here in the Query type. For example, items, requisitions. However,
   if you don't want requisition lines to be queryable, don't put them here, instead have them as a field on a requisition.
   """
   type Query {
-    "The name of an Item"
+    "All items"
     items: [Item]
+
+    "All facilities"
+    stores: [Store]
+
+    "All lines of all requisitions"
+    requisitionLines: [RequisitionLine]
+
+    "All requisitions for all stores"
+    requisitions: [Requisition]
+
+    "Fetch a particular requisition by id"
+    getRequisition(id: String): Requisition
+
+    "Fetch a particular item by id"
+    getItem(id: String): Item
+
+    "Fetch a particular store by id"
+    getStore(id: String): Store
   }
 `;
-
-// Basic test data
-const items = [
-  {
-    name: "Ibuprofen",
-    code: "IBU",
-  },
-  {
-    name: "Paracetamol",
-    code: "PCT",
-  },
-];
 
 export const QueryResolvers = {
   Query: {
     items: () => items,
+    stores: () => stores,
+    requisitionLines: () => requisitionLines,
+    requisitions: () => requisitions,
+    getRequisition: (_: any, args: any) =>
+      requisitions.find((req) => req.id === args.id),
+    getItem: (_: any, args: any) => items.find((item) => item.id === args.id),
+    getStore: (_: any, args: any) =>
+      stores.find((store) => store.id === args.id),
   },
 };

--- a/src/schema/Requisition.ts
+++ b/src/schema/Requisition.ts
@@ -1,5 +1,7 @@
 import { gql } from "apollo-server";
 
+import { requisitionLines } from "./mockData";
+
 export const RequisitionSchema = gql`
   """
   A requisition.
@@ -9,9 +11,18 @@ export const RequisitionSchema = gql`
     id: ID
 
     "The lines of this requisition"
-    lines: [RequisitionLines]
+    lines: [RequisitionLine]
 
     "The store this requisition is made in"
     store: Store
   }
 `;
+
+export const RequisitionResolvers = {
+  Requisition: {
+    lines: (requisition: any) =>
+      requisitionLines.filter((requisitionLine) =>
+        requisition.lines.includes(requisitionLine.id)
+      ),
+  },
+};

--- a/src/schema/RequisitionLine.ts
+++ b/src/schema/RequisitionLine.ts
@@ -1,5 +1,7 @@
 import { gql } from "apollo-server";
 
+import { items } from "./mockData";
+
 export const RequisitionLineSchema = gql`
   """
   A RequisitionLine record. A line on a requisition.
@@ -15,3 +17,10 @@ export const RequisitionLineSchema = gql`
     quantity: Int
   }
 `;
+
+export const RequisitionLineResolvers = {
+  RequisitionLine: {
+    item: (requisitionLine: any) =>
+      items.find((item) => item.id === requisitionLine.item),
+  },
+};

--- a/src/schema/Store.ts
+++ b/src/schema/Store.ts
@@ -1,5 +1,7 @@
 import { gql } from "apollo-server";
 
+import { requisitions, items } from "./mockData";
+
 export const StoreSchema = gql`
   """
   A generic Store record. Represents a physical facility.
@@ -21,3 +23,14 @@ export const StoreSchema = gql`
     requisitions: [Requisition]
   }
 `;
+
+export const StoreResolver = {
+  Store: {
+    requisitions: (store: any) =>
+      requisitions.filter((requisition) =>
+        store.requisitions.includes(requisition.id)
+      ),
+    items: (store: any) =>
+      items.filter((item) => store.items.includes(item.id)),
+  },
+};

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,8 +1,11 @@
 import { makeExecutableSchema } from "apollo-server";
 
-import { StoreSchema } from "./Store";
-import { RequisitionSchema } from "./Requisition";
-import { RequisitionLineSchema } from "./RequisitionLine";
+import { StoreSchema, StoreResolver } from "./Store";
+import { RequisitionSchema, RequisitionResolvers } from "./Requisition";
+import {
+  RequisitionLineSchema,
+  RequisitionLineResolvers,
+} from "./RequisitionLine";
 import { ItemSchema } from "./Item";
 import { QuerySchema, QueryResolvers } from "./Query";
 
@@ -37,4 +40,10 @@ export const typeDefs = [
   RequisitionSchema,
   RequisitionLineSchema,
 ];
-export const resolvers = [QueryResolvers];
+
+export const resolvers = [
+  QueryResolvers,
+  StoreResolver,
+  RequisitionResolvers,
+  RequisitionLineResolvers,
+];

--- a/src/schema/mockData.ts
+++ b/src/schema/mockData.ts
@@ -1,0 +1,57 @@
+export const items = [
+  {
+    id: "ibu1",
+    name: "Ibuprofen",
+    code: "IBU",
+  },
+  {
+    id: "para1",
+    name: "Paracetamol",
+    code: "PCT",
+  },
+];
+
+export const stores = [
+  {
+    id: "store1",
+    name: "store one",
+    code: "store1",
+    items: ["ibu1"],
+    requisitions: ["req1"],
+  },
+  {
+    id: "store2",
+    name: "store two",
+    code: "store2",
+    items: ["ibu1", "para1"],
+    requisitions: ["req2"],
+  },
+];
+
+export const requisitionLines = [
+  {
+    id: "reqLine1",
+    item: "ibu1",
+    quantity: 1,
+  },
+  {
+    id: "reqLine2",
+    item: "para1",
+    quantity: 5,
+  },
+  {
+    id: "reqLine3",
+    item: "ibu1",
+    quantity: 10,
+  },
+  {
+    id: "reqLine4",
+    item: "para1",
+    quantity: 50,
+  },
+];
+
+export const requisitions = [
+  { id: "req1", store: "store1", lines: ["reqLine1", "reqLine2"] },
+  { id: "req2", store: "store2", lines: ["reqLine3", "reqLine4"] },
+];


### PR DESCRIPTION
Fixes #8 

Just brings some basic resolvers - can now query all fields of all types i.e. execute the following query on `http://localhost:4000`

```

query{
  getRequisition(id:"req1"){
  lines{
    item{
      name
    	}
  	}
	}
  getStore(id:"store1"){
    name
  }
  stores{
    requisitions{
    		lines{
          item{
            name
        }
      }
		}
	}
}
```