### PR TITLE
Add site partial replication

### DIFF
--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -46,6 +46,7 @@ const main = async () => {
             _id: syncId,
             source: `http://${sourceAuth}@${sourceHostname}:${sourcePort}/ocsupply`,
             target: `http://${targetAuth}@${targetHostname}:${targetPort}/ocsupply`,
+            selector: { site: { code: targetSite } },
             create_target: false,
             continuous: false            
         }


### PR DESCRIPTION
Fixes #16.

Ended up being a lot less changes than expected!

Played around with views, decided to go with a more simple document structure to demonstrate how simple partial replication can be using couch.

Basic logic is each replication document has a selector which tells the master only to replicate the document which matches that site. Very simple way of doing it, but I think easier to follow than other ways I tried using views (e.g. master has a single document containing an array of sites, define a view which lets you lookup sites by `doc.code`, then replicate that). 

Note that neither of two approaches above would scale, but can recursively split the document out multiple item documents etc, and map/reduce them as needed to get what we need. Would be a case of deciding on the optional balance between not syncing redundant data (i..e stuff that hasn't changed), and not having too many documents.

That's my thinking, anyway! Feedback welcome!