### PR TITLE
#40 fix mock data for ibuprofen item

### DIFF
--- a/scripts/items.json
+++ b/scripts/items.json
@@ -12,7 +12,7 @@
     "code": "PARA"
   },
   {
-    "id": "item_ibu",
+    "id": "item_ibup",
     "type": "item",
     "name": "Ibuprofen",
     "code": "IBUP"

--- a/scripts/requisitions.json
+++ b/scripts/requisitions.json
@@ -26,7 +26,7 @@
     "toStoreId": "facility_a",
     "lines": [
       { "itemId": "item_aspi", "quantity": 300 },
-      { "itemId": "item_ibu", "quantity": 400 }
+      { "itemId": "item_ibup", "quantity": 400 }
     ]
   },
   {
@@ -36,7 +36,7 @@
     "toStoreId": "facility_a",
     "lines": [
       { "itemId": "item_para", "quantity": 500 },
-      { "itemId": "item_ibu", "quantity": 600 }
+      { "itemId": "item_ibup", "quantity": 600 }
     ]
   },
   {
@@ -65,7 +65,7 @@
     "requestRequisitionId": "requisition_3",
     "lines": [
       { "itemId": "item_aspi", "quantity": 300 },
-      { "itemId": "item_ibu", "quantity": 500 }
+      { "itemId": "item_ibup", "quantity": 500 }
     ]
   },
   {
@@ -76,7 +76,7 @@
     "requestRequisitionId": "requisition_4",
     "lines": [
       { "itemId": "item_para", "quantity": 500 },
-      { "itemId": "item_ibu", "quantity": 600 }
+      { "itemId": "item_ibup", "quantity": 600 }
     ]
   }
 ]


### PR DESCRIPTION
Fixes #40.

Updates all `item_ibu` ids to `item_ibup`.